### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 license = "MIT"
 description = "impl screencopy for wayland"
 authors = ["Decodertalkers <aakari@tutanota.com>"]
-homepage = "https://github.com/Decodetalkers/haruhishot"
+repository = "https://github.com/Decodetalkers/haruhishot"
 documentation = "https://docs.rs/libharuhishot/"
 keywords = ["wayland"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2024"
 license = "MIT"
 description = "impl screencopy for wayland"
 authors = ["Decodertalkers <aakari@tutanota.com>"]
+homepage = "https://github.com/Decodetalkers/haruhishot"
 repository = "https://github.com/Decodetalkers/haruhishot"
 documentation = "https://docs.rs/libharuhishot/"
 keywords = ["wayland"]
@@ -16,6 +17,7 @@ license.workspace = true
 description = "haruhishot"
 authors.workspace = true
 homepage.workspace = true
+repository.workspace = true
 keywords.workspace = true
 
 [workspace]

--- a/libharuhishot/Cargo.toml
+++ b/libharuhishot/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "impl screencopy for wayland"
 authors.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/libharuhishot/"
 keywords = ["wayland"]
 readme = "README.md"


### PR DESCRIPTION
More explanation: https://github.com/szabgab/rust-digger/issues/91